### PR TITLE
Add support for Google Chrome Dev browser

### DIFF
--- a/src/browsers/chrome-dev.ts
+++ b/src/browsers/chrome-dev.ts
@@ -1,0 +1,15 @@
+import type { PossibleExecutables } from './types';
+
+export default {
+  linux: ['google-chrome-dev'],
+  darwin: [
+    '/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev'
+  ],
+  win32: [
+    process.env.LOCALAPPDATA + '\\Google\\Chrome Dev\\Application\\chrome.exe',
+    process.env.ProgramW6432 + '\\Google\\Chrome Dev\\Application\\chrome.exe',
+    process.env.ProgramFiles + '\\Google\\Chrome Dev\\Application\\chrome.exe',
+    process.env['ProgramFiles(x86)'] +
+      '\\Google\\Chrome Dev\\Application\\chrome.exe'
+  ]
+} as PossibleExecutables; 

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -1,6 +1,7 @@
 import brave from './brave';
 import chrome from './chrome';
 import chromeCanary from './chrome-canary';
+import chromeDev from './chrome-dev';
 import chromium from './chromium';
 import firefox from './firefox';
 import firefoxDeveloperEdition from './firefox-developer-edition';
@@ -19,6 +20,7 @@ export default {
   'Firefox Nightly': firefoxNightly,
   'Firefox': firefox,
   'Google Chrome Canary': chromeCanary,
+  'Google Chrome Dev': chromeDev,
   'Google Chrome': chrome,
   'Internet Explorer': internetExplorer,
   'Microsoft Edge': microsoftEdge,


### PR DESCRIPTION
# Add support for Google Chrome Dev browser

This PR adds support for detecting Google Chrome Dev, which is now available on Linux, macOS, and Windows platforms. 

## Changes:

1. Added a new file `src/browsers/chrome-dev.ts` with proper executables paths for all supported platforms
2. Updated `src/browsers/index.ts` to include Chrome Dev in the list of supported browsers

## Testing:

The changes have been tested on macOS and Chrome Dev was successfully detected by the library.

## Screenshots:

Here's the output showing Chrome Dev detection:
```
[
  {
    browser: 'Google Chrome Dev',
    executable: '/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev'
  },
  {
    browser: 'Google Chrome',
    executable: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
  },
  ...
]
```